### PR TITLE
Load 64 bit version of the FAME chli.dll on 64 bit systems

### DIFF
--- a/R/windows/zzz.R
+++ b/R/windows/zzz.R
@@ -21,6 +21,8 @@
 
     chliPath <- file.path(fameDir, "chli.dll")
 
+    if(Sys.getenv("R_ARCH") == "/x64")
+      fameDir <- file.path(fameDir, "64")
     if(!file.exists(chliPath))
       stop(paste("chli.dll not found in", fameDir))
     dyn.load(chliPath, local = FALSE)


### PR DESCRIPTION
This is to avoid "LoadLibrary failure:  %1 is not a valid Win32 application" on package load on 64 bit systems, necessary since the FAME directory by default contains the 32 bit DLL in the root.